### PR TITLE
make pdfutil-optimize posix-compliant

### DIFF
--- a/overlay/bin/pdfutil-optimize
+++ b/overlay/bin/pdfutil-optimize
@@ -98,7 +98,7 @@ fi
 
 # http://stackoverflow.com/questions/16152583/tell-if-a-file-is-pdf-in-bash
 IS_PDF=$(file "$INPUT_FILE" | grep -q 'PDF' && echo 'YES'  || echo 'NO')
-if [ "$IS_PDF" == "NO" ] ; then
+if [ "$IS_PDF" = "NO" ] ; then
   echo "ERROR: input file does not seem to be a PDF"
   exit 1
 fi


### PR DESCRIPTION
== is not valid for `test` in POSIX sh, only = is allowed.
https://linux.die.net/man/1/dash